### PR TITLE
send empty encryption_opts when no encryption_key provided

### DIFF
--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -67,10 +67,13 @@ module Fluent
       end
 
       # The customer-supplied, AES-256 encryption key and hash used to encrypt the file.
-      @encryption_opts = {
-        encryption_key: @encryption_key,
-        encryption_key_sha256: @encryption_key_sha256
-      }
+      @encryption_opts = {}
+      if @encryption_key
+        @encryption_opts = {
+          encryption_key: @encryption_key,
+          encryption_key_sha256: @encryption_key_sha256
+        }
+      end
 
       if @object_metadata
         @object_metadata_hash = @object_metadata.map {|m| [m.key, m.value] }.to_h


### PR DESCRIPTION
We used gcs plugin without encryption options, but got the errors when using the gcs plugin

```
2017-01-09 08:43:28 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2017-01-09 08:43:29 +0000 error_class="ArgumentError" error="unknown keyword: encryption_key_sha256" plugin_id="object:3ff2b29b2d84"
  2017-01-09 08:43:28 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-gcs-0.1.1/lib/fluent/plugin/out_gcs.rb:151:in `generate_path'
  2017-01-09 08:43:28 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-gcs-0.1.1/lib/fluent/plugin/out_gcs.rb:103:in `write'
  2017-01-09 08:43:28 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.31/lib/fluent/buffer.rb:354:in `write_chunk'
  2017-01-09 08:43:28 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.31/lib/fluent/buffer.rb:333:in `pop'
  2017-01-09 08:43:28 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.31/lib/fluent/output.rb:342:in `try_flush'
```

The pull request will pass `{}` to google-client-api when no encryption information provided