### PR TITLE
Remote encryption_key_sha256 parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ Permission for the object in GCS. Acceptable values are:
 
 Default is nil (bucket default object ACL). See also [official document](https://cloud.google.com/storage/docs/access-control/lists).
 
-**encryption_key**, **encryption_key_sha256**
+**encryption_key**
 
 You can also choose to provide your own AES-256 key for server-side encryption. See also [Customer-supplied encryption keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).
+
+`encryption_key_sha256` will be calculated using encryption_key.
 
 **overwrite**
 

--- a/fluent-plugin-gcs.gemspec
+++ b/fluent-plugin-gcs.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "fluentd", "~> 0.12.0"
-  spec.add_runtime_dependency "google-cloud-storage", "~> 0.21"
+  spec.add_runtime_dependency "google-cloud-storage", "~> 0.23.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -44,8 +44,6 @@ module Fluent
                  desc: "Permission for the object in GCS"
     config_param :encryption_key, :string, default: nil, secret: true,
                  desc: "Customer-supplied, AES-256 encryption key"
-    config_param :encryption_key_sha256, :string, default: nil, secret: true,
-                 desc: "SHA256 hash of the customer-supplied, AES-256 encryption key"
     config_section :object_metadata, required: false do
       config_param :key, :string, default: ""
       config_param :value, :string, default: ""
@@ -58,18 +56,13 @@ module Fluent
     def configure(conf)
       super
 
-      if @encryption_key && @encryption_key_sha256.nil?
-        raise Fluent::ConfigError, "encryption_key_sha256 parameter must be provided if `encryption_key` is provided."
-      end
-
       if @hex_random_length > MAX_HEX_RANDOM_LENGTH
         raise Fluent::ConfigError, "hex_random_length parameter should be set to #{MAX_HEX_RANDOM_LENGTH} characters or less."
       end
 
-      # The customer-supplied, AES-256 encryption key and hash used to encrypt the file.
+      # The customer-supplied, AES-256 encryption key that will be used to encrypt the file.
       @encryption_opts = {
         encryption_key: @encryption_key,
-        encryption_key_sha256: @encryption_key_sha256
       }
 
       if @object_metadata

--- a/test/plugin/test_out_gcs.rb
+++ b/test/plugin/test_out_gcs.rb
@@ -41,17 +41,7 @@ class GCSOutputTest < Test::Unit::TestCase
       assert_equal "out_file", driver.instance.instance_variable_get(:@format)
       assert_equal nil, driver.instance.acl
       assert_equal nil, driver.instance.encryption_key
-      assert_equal nil, driver.instance.encryption_key_sha256
       assert_equal [], driver.instance.object_metadata
-    end
-
-    def test_configure_with_encryption_key
-      assert_raise Fluent::ConfigError do
-        create_driver(config(CONFIG, "encryption_key aaaaa"))
-      end
-      assert_nothing_raised do
-        create_driver(config(CONFIG, "encryption_key aaaaa" , "encryption_key_sha256 bbbbbb"))
-      end
     end
 
     def test_configure_with_hex_random_length
@@ -225,7 +215,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -234,7 +223,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
@@ -245,7 +233,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -254,7 +241,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "text/plain",
         content_encoding: "gzip",
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
@@ -265,7 +251,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -274,7 +259,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "text/plain",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.txt", enc_opts, upload_opts)
@@ -285,7 +269,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -294,7 +277,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/json",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.json", enc_opts, upload_opts)
@@ -305,7 +287,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -314,7 +295,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       Timecop.freeze(Time.parse("2016-01-02 01:00:00 JST")) do
@@ -323,11 +303,10 @@ class GCSOutputTest < Test::Unit::TestCase
     end
 
     def test_write_with_encryption
-      conf = config(CONFIG, "encryption_key aaa", "encryption_key_sha256 bbb")
+      conf = config(CONFIG, "encryption_key aaa")
 
       enc_opts = {
         encryption_key: "aaa",
-        encryption_key_sha256: "bbb"
       }
 
       upload_opts = {
@@ -336,7 +315,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: "aaa",
-        encryption_key_sha256: "bbb"
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
@@ -347,7 +325,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -356,7 +333,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
@@ -376,7 +352,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -385,7 +360,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
@@ -396,7 +370,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -405,7 +378,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       any_instance_of(Fluent::MemoryBufferChunk) do |b|
@@ -428,7 +400,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       upload_opts = {
@@ -437,7 +408,6 @@ class GCSOutputTest < Test::Unit::TestCase
         content_type: "application/gzip",
         content_encoding: nil,
         encryption_key: nil,
-        encryption_key_sha256: nil
       }.merge(enc_opts)
 
       check_upload(conf) do |bucket|
@@ -452,7 +422,6 @@ class GCSOutputTest < Test::Unit::TestCase
 
       enc_opts = {
         encryption_key: nil,
-        encryption_key_sha256: nil
       }
 
       assert_raise do


### PR DESCRIPTION
Since google cloud storage 0.23.0, encryption_key_sha 256 has been deleted from the parameter and it is removed from the setting.

https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-storage/CHANGELOG.md#0230--2016-12-8