### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gem install fluent-plugin-gcs
   object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
   path logs/${tag}/%Y/%m/%d/
 
-  # if you want to use ${tag} or %Y/%m/%d/ like syntax in path / s3_object_key_format,
+  # if you want to use ${tag} or %Y/%m/%d/ like syntax in path / object_key_format,
   # need to specify tag for ${tag} and time for %Y/%m/%d in <buffer> argument.
   <buffer tag,time>
     @type file

--- a/README.md
+++ b/README.md
@@ -11,6 +11,35 @@ gem install fluent-plugin-gcs
 
 ## Examples
 
+### For v0.14 style
+
+```
+<match pattern>
+  @type gcs
+
+  project YOUR_PROJECT
+  keyfile YOUR_KEYFILE_PATH
+  bucket YOUR_GCS_BUCKET_NAME
+  object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
+  path logs/${tag}/%Y/%m/%d/
+
+  # if you want to use ${tag} or %Y/%m/%d/ like syntax in path / s3_object_key_format,
+  # need to specify tag for ${tag} and time for %Y/%m/%d in <buffer> argument.
+  <buffer tag,time>
+    @type file
+    path /var/log/fluent/gcs
+    timekey 3600 # 1 hour partition
+    timekey_wait 10m
+    timekey_use_utc true # use utc
+  </buffer>
+  <format>
+    @type json
+  </format>
+</match>
+```
+
+### For v0.12 style
+
 ```
 <match pattern>
   @type gcs

--- a/fluent-plugin-gcs.gemspec
+++ b/fluent-plugin-gcs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", "~> 0.12.0"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_runtime_dependency "google-cloud-storage", "~> 0.23.2"
 
   spec.add_development_dependency "bundler", "~> 1.13"

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -90,6 +90,7 @@ module Fluent::Plugin
       # For backward compatibility
       # TODO: Remove time_slice_format when end of support compat_parameters
       @configured_time_slice_format = conf['time_slice_format']
+      @time_slice_with_tz = Fluent::Timezone.formatter(@timekey_zone, @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey']))
     end
 
     def start
@@ -160,7 +161,7 @@ module Fluent::Plugin
       time_slice = if metadata.timekey.nil?
                      ''.freeze
                    else
-                     Time.at(metadata.timekey).utc.strftime(time_slice_format)
+                     @time_slice_with_tz.call(metadata.timekey)
                    end
       tags = {
         "%{file_extension}" => @object_creator.file_extension,

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -150,7 +150,7 @@ module Fluent::Plugin
 
     def format_path(time_slice_format, time_slice)
       now = Time.strptime(time_slice, time_slice_format)
-      (@localtime ? now : now.utc).strftime(@path)
+      (@buffer_config.timekey_use_utc ? now.utc : now).strftime(@path)
     end
 
     def generate_path(chunk, i = 0, prev = nil)

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -149,8 +149,6 @@ module Fluent::Plugin
     end
 
     def format_path(time_slice_format, time_slice)
-      time_slice_format = @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey'])
-
       now = Time.strptime(time_slice, time_slice_format)
       (@localtime ? now : now.utc).strftime(@path)
     end

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -149,11 +149,6 @@ module Fluent::Plugin
       Digest::MD5.hexdigest(chunk.unique_id)[0...@hex_random_length]
     end
 
-    def format_path(time_slice_format, time_slice)
-      now = Time.strptime(time_slice, time_slice_format)
-      (@buffer_config.timekey_use_utc ? now.utc : now).strftime(@path)
-    end
-
     def generate_path(chunk, i = 0, prev = nil)
       metadata = chunk.metadata
       time_slice_format = @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey'])
@@ -168,7 +163,7 @@ module Fluent::Plugin
         "%{hex_random}" => hex_random(chunk),
         "%{hostname}" => Socket.gethostname,
         "%{index}" => i,
-        "%{path}" => format_path(time_slice_format, time_slice),
+        "%{path}" => @path,
         "%{time_slice}" => time_slice,
         "%{uuid_flush}" => SecureRandom.uuid,
       }

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -151,8 +151,6 @@ module Fluent::Plugin
 
     def generate_path(chunk, i = 0, prev = nil)
       metadata = chunk.metadata
-      time_slice_format = @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey'])
-
       time_slice = if metadata.timekey.nil?
                      ''.freeze
                    else

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -173,6 +173,7 @@ module Fluent::Plugin
         "%{uuid_flush}" => SecureRandom.uuid,
       }
       path = @object_key_format.gsub(Regexp.union(tags.keys), tags)
+      path = extract_placeholders(path, metadata)
       return path unless @gcs_bucket.find_file(path, @encryption_opts)
 
       if path == prev

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -4,10 +4,13 @@ require "socket"
 
 require "fluent/plugin/gcs/object_creator"
 require "fluent/plugin/gcs/version"
+require "fluent/plugin/output"
 
-module Fluent
-  class GCSOutput < TimeSlicedOutput
+module Fluent::Plugin
+  class GCSOutput < Output
     Fluent::Plugin.register_output("gcs", self)
+
+    helpers :compat_parameters, :formatter, :inject
 
     def initialize
       super
@@ -51,9 +54,21 @@ module Fluent
       config_param :value, :string, default: ""
     end
 
+    DEFAULT_FORMAT_TYPE = "out_file"
+
+    config_section :format do
+      config_set_default :@type, DEFAULT_FORMAT_TYPE
+    end
+
+    config_section :buffer do
+      config_set_default :chunk_keys, ['time']
+      config_set_default :timekey, (60 * 60 * 24)
+    end
+
     MAX_HEX_RANDOM_LENGTH = 32
 
     def configure(conf)
+      compat_parameters_convert(conf, :buffer, :formatter, :inject)
       super
 
       if @hex_random_length > MAX_HEX_RANDOM_LENGTH
@@ -69,10 +84,12 @@ module Fluent
         @object_metadata_hash = @object_metadata.map {|m| [m.key, m.value] }.to_h
       end
 
-      @formatter = Fluent::Plugin.new_formatter(@format)
-      @formatter.configure(conf)
+      @formatter = formatter_create
 
       @object_creator = Fluent::GCS.discovered_object_creator(@store_as, transcoding: @transcoding)
+      # For backward compatibility
+      # TODO: Remove time_slice_format when end of support compat_parameters
+      @configured_time_slice_format = conf['time_slice_format']
     end
 
     def start
@@ -89,7 +106,12 @@ module Fluent
     end
 
     def format(tag, time, record)
-      @formatter.format(tag, time, record)
+      r = inject_values_to_record(tag, time, record)
+      @formatter.format(tag, time, r)
+    end
+
+    def multi_workers_ready?
+      true
     end
 
     def write(chunk)
@@ -126,19 +148,29 @@ module Fluent
       Digest::MD5.hexdigest(chunk.unique_id)[0...@hex_random_length]
     end
 
-    def format_path(chunk)
-      now = Time.strptime(chunk.key, @time_slice_format)
+    def format_path(time_slice_format, time_slice)
+      time_slice_format = @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey'])
+
+      now = Time.strptime(time_slice, time_slice_format)
       (@localtime ? now : now.utc).strftime(@path)
     end
 
     def generate_path(chunk, i = 0, prev = nil)
+      metadata = chunk.metadata
+      time_slice_format = @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey'])
+
+      time_slice = if metadata.timekey.nil?
+                     ''.freeze
+                   else
+                     Time.at(metadata.timekey).utc.strftime(time_slice_format)
+                   end
       tags = {
         "%{file_extension}" => @object_creator.file_extension,
         "%{hex_random}" => hex_random(chunk),
         "%{hostname}" => Socket.gethostname,
         "%{index}" => i,
-        "%{path}" => format_path(chunk),
-        "%{time_slice}" => chunk.key,
+        "%{path}" => format_path(time_slice_format, time_slice),
+        "%{time_slice}" => time_slice,
         "%{uuid_flush}" => SecureRandom.uuid,
       }
       path = @object_key_format.gsub(Regexp.union(tags.keys), tags)
@@ -152,6 +184,17 @@ module Fluent
         raise "object `#{path}` already exists"
       end
       generate_path(chunk, i + 1, path)
+    end
+
+    # This is stolen from Fluentd
+    def timekey_to_timeformat(timekey)
+      case timekey
+      when nil          then ''
+      when 0...60       then '%Y%m%d%H%M%S' # 60 exclusive
+      when 60...3600    then '%Y%m%d%H%M'
+      when 3600...86400 then '%Y%m%d%H'
+      else                   '%Y%m%d'
+      end
     end
   end
 end

--- a/test/plugin/test_out_gcs.rb
+++ b/test/plugin/test_out_gcs.rb
@@ -1,7 +1,11 @@
 require "helper"
+require "fluent/test/driver/output"
+require "fluent/test/helpers"
 require "google/cloud/storage"
 
 class GCSOutputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
   def setup
     Fluent::Test.setup
   end
@@ -16,7 +20,7 @@ class GCSOutputTest < Test::Unit::TestCase
   EOC
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::TimeSlicedOutputTestDriver.new(Fluent::GCSOutput) do
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::GCSOutput) do
       attr_accessor :object_creator, :encryption_opts
     end.configure(conf)
   end
@@ -126,70 +130,79 @@ class GCSOutputTest < Test::Unit::TestCase
       storage.bucket { bucket }
       stub(Google::Cloud::Storage).new { storage }
 
-      @time = Time.parse("2016-01-01 12:00:00 UTC").to_i
+      @time = event_time("2016-01-01 12:00:00 UTC")
     end
 
     def test_format
       driver = create_driver
-      driver.emit({"a"=>1}, @time)
-      driver.emit({"a"=>2}, @time)
-      driver.expect_format %[2016-01-01T12:00:00Z\ttest\t{"a":1}\n]
-      driver.expect_format %[2016-01-01T12:00:00Z\ttest\t{"a":2}\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1})
+        driver.feed(@time, {"a"=>2})
+      end
+      assert_equal %[2016-01-01T12:00:00Z\ttest\t{"a":1}\n], driver.formatted[0]
+      assert_equal %[2016-01-01T12:00:00Z\ttest\t{"a":2}\n], driver.formatted[1]
     end
 
     def test_format_included_tag_and_time
       driver = create_driver(config(CONFIG, 'include_tag_key true', 'include_time_key true'))
-      driver.emit({"a"=>1}, @time)
-      driver.emit({"a"=>2}, @time)
-      driver.expect_format %[2016-01-01T12:00:00Z\ttest\t{"a":1,"tag":"test","time":"2016-01-01T12:00:00Z"}\n]
-      driver.expect_format %[2016-01-01T12:00:00Z\ttest\t{"a":2,"tag":"test","time":"2016-01-01T12:00:00Z"}\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1})
+        driver.feed(@time, {"a"=>2})
+      end
+      assert_equal %[2016-01-01T12:00:00Z\ttest\t{"a":1,"tag":"test","time":"2016-01-01T12:00:00Z"}\n],
+                   driver.formatted[0]
+      assert_equal %[2016-01-01T12:00:00Z\ttest\t{"a":2,"tag":"test","time":"2016-01-01T12:00:00Z"}\n],
+                   driver.formatted[1]
     end
 
     def test_format_with_format_ltsv
       driver = create_driver(config(CONFIG, 'format ltsv'))
-      driver.emit({"a"=>1, "b"=>1}, @time)
-      driver.emit({"a"=>2, "b"=>2}, @time)
-      driver.expect_format %[a:1\tb:1\n]
-      driver.expect_format %[a:2\tb:2\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1, "b"=>1})
+        driver.feed(@time, {"a"=>2, "b"=>2})
+      end
+      assert_equal %[a:1\tb:1\n], driver.formatted[0]
+      assert_equal %[a:2\tb:2\n], driver.formatted[1]
     end
 
     def test_format_with_format_json
       driver = create_driver(config(CONFIG, 'format json'))
-      driver.emit({"a"=>1}, @time)
-      driver.emit({"a"=>2}, @time)
-      driver.expect_format %[{"a":1}\n]
-      driver.expect_format %[{"a":2}\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1})
+        driver.feed(@time, {"a"=>2})
+      end
+      assert_equal %[{"a":1}\n], driver.formatted[0]
+      assert_equal %[{"a":2}\n], driver.formatted[1]
     end
 
     def test_format_with_format_json_included_tag
       driver = create_driver(config(CONFIG, 'format json', 'include_tag_key true'))
-      driver.emit({"a"=>1}, @time)
-      driver.emit({"a"=>2}, @time)
-      driver.expect_format %[{"a":1,"tag":"test"}\n]
-      driver.expect_format %[{"a":2,"tag":"test"}\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1})
+        driver.feed(@time, {"a"=>2})
+      end
+      assert_equal %[{"a":1,"tag":"test"}\n], driver.formatted[0]
+      assert_equal %[{"a":2,"tag":"test"}\n], driver.formatted[1]
     end
 
     def test_format_with_format_json_included_time
       driver = create_driver(config(CONFIG, 'format json', 'include_time_key true'))
-      driver.emit({"a"=>1}, @time)
-      driver.emit({"a"=>2}, @time)
-      driver.expect_format %[{"a":1,"time":"2016-01-01T12:00:00Z"}\n]
-      driver.expect_format %[{"a":2,"time":"2016-01-01T12:00:00Z"}\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1})
+        driver.feed(@time, {"a"=>2})
+      end
+      assert_equal %[{"a":1,"time":"2016-01-01T12:00:00Z"}\n], driver.formatted[0]
+      assert_equal %[{"a":2,"time":"2016-01-01T12:00:00Z"}\n], driver.formatted[1]
     end
 
     def test_format_with_format_json_included_tag_and_time
       driver = create_driver(config(CONFIG, 'format json', 'include_tag_key true', 'include_time_key true'))
-      driver.emit({"a"=>1}, @time)
-      driver.emit({"a"=>2}, @time)
-      driver.expect_format %[{"a":1,"tag":"test","time":"2016-01-01T12:00:00Z"}\n]
-      driver.expect_format %[{"a":2,"tag":"test","time":"2016-01-01T12:00:00Z"}\n]
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(@time, {"a"=>1})
+        driver.feed(@time, {"a"=>2})
+      end
+      assert_equal %[{"a":1,"tag":"test","time":"2016-01-01T12:00:00Z"}\n], driver.formatted[0]
+      assert_equal %[{"a":2,"tag":"test","time":"2016-01-01T12:00:00Z"}\n], driver.formatted[1]
     end
   end
 
@@ -207,8 +220,9 @@ class GCSOutputTest < Test::Unit::TestCase
       stub(Google::Cloud::Storage).new { storage }
 
       driver = create_driver(conf)
-      driver.emit({"a"=>1}, Time.parse("2016-01-01 15:00:00 UTC").to_i)
-      driver.run
+      driver.run(default_tag: "test") do
+        driver.feed(event_time("2016-01-01 15:00:00 UTC"), {"a"=>1})
+      end
     end
 
     def test_write_with_gzip
@@ -409,7 +423,7 @@ class GCSOutputTest < Test::Unit::TestCase
         encryption_key: nil,
       }.merge(enc_opts)
 
-      any_instance_of(Fluent::MemoryBufferChunk) do |b|
+      any_instance_of(Fluent::Plugin::Buffer::MemoryChunk) do |b|
         # Memo: Digest::MD5.hexdigest("unique_id") => "69080cee5b6d4c35a8bbf5c48335fe08"
         stub(b).unique_id { "unique_id" }
       end

--- a/test/plugin/test_out_gcs.rb
+++ b/test/plugin/test_out_gcs.rb
@@ -322,6 +322,38 @@ class GCSOutputTest < Test::Unit::TestCase
       end
     end
 
+    def test_write_with_placeholder_in_path
+      conf = config_element('ROOT', '', {
+                              "project" => "test_project",
+                              "keyfile" => "test_keyfile",
+                              "bucket"  => "test_bucket",
+                              "path"    => "log/${tag}/",
+                              "utc"     => ""}, [
+                              config_element('buffer', 'tag, time',
+                                             {'@type'        => "memory",
+                                              'timekey'      => 86400,
+                                              'timekey_wait' => '10m',
+                                             })
+                            ])
+
+      enc_opts = {
+        encryption_key: nil,
+      }
+
+      upload_opts = {
+        metadata: {},
+        acl: nil,
+        storage_class: nil,
+        content_type: "application/gzip",
+        content_encoding: nil,
+        encryption_key: nil,
+      }.merge(enc_opts)
+
+      Timecop.freeze(Time.parse("2016-01-02 01:00:00 JST")) do
+        check_upload(conf, "log/test/20160101_0.gz", enc_opts, upload_opts)
+      end
+    end
+
     def test_write_with_encryption
       conf = config(CONFIG, "encryption_key aaa")
 


### PR DESCRIPTION
Hi, thanks for paying attention to use v0.14 Plugin API.

I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,

Will fix #5.