### PR TITLE
Pass chunk instance directly instead of chunk.metatada into placeholder API

### DIFF
--- a/fluent-plugin-gcs.gemspec
+++ b/fluent-plugin-gcs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
+  spec.add_runtime_dependency "fluentd", [">= 0.14.22", "< 2"]
   spec.add_runtime_dependency "google-cloud-storage", "~> 1.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -166,7 +166,7 @@ module Fluent::Plugin
         "%{uuid_flush}" => SecureRandom.uuid,
       }
       path = @object_key_format.gsub(Regexp.union(tags.keys), tags)
-      path = extract_placeholders(path, metadata)
+      path = extract_placeholders(path, chunk)
       return path unless @gcs_bucket.find_file(path, @encryption_opts)
 
       if path == prev


### PR DESCRIPTION
We should use `expand_placeholders(chunk)` instead of `expand_placeholders(chunk.metadata)`.