### PR TITLE
Add support of blind write to GCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 New features / Enhancements
 
+## [0.4.1] - 2020/04/17
+
+New features
+- [Support blind write to GSC](https://github.com/daichirata/fluent-plugin-gcs/pull/7)
+
 ## [0.4.0] - 2019/04/01
 
 New features / Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ New features / Enhancements
 ## [0.4.1] - 2020/04/17
 
 New features
-- [Support blind write to GSC](https://github.com/daichirata/fluent-plugin-gcs/pull/7)
+- [Support blind write to GSC](https://github.com/daichirata/fluent-plugin-gcs/pull/14)
 
 ## [0.4.0] - 2019/04/01
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Doesn't check if an object exists in GCS before writing. Default is false.
 Allows to avoid granting of `storage.objects.get` permission.
 
 Warning! If the object exists and `storage.objects.delete` permission is not
-granted, there will be an unrecoverable error. Usage of `%{hex_random}` is
+granted, it will result in an unrecoverable error. Usage of `%{hex_random}` is
 recommended.
 
 ### ObjectMetadata

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ Use UTC instead of local time.
 
 And see [official Time Sliced Output article](http://docs.fluentd.org/articles/output-plugin-overview#time-sliced-output-parameters)
 
+**blind_write**
+
+Doesn't check if an object exists in GCS before writing. Default is false.
+
+Allows to avoid granting of `storage.objects.get` permission.
+
+Warning! If the obkect exists and `storage.objects.delete` permission is not
+granted, there will be an unrecoverable error. Usage of `%{hex_random}` is
+recommended.
+
 ### ObjectMetadata
 
 User provided web-safe keys and arbitrary string values that will returned with requests for the file as "x-goog-meta-" response headers.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Doesn't check if an object exists in GCS before writing. Default is false.
 
 Allows to avoid granting of `storage.objects.get` permission.
 
-Warning! If the obkect exists and `storage.objects.delete` permission is not
+Warning! If the object exists and `storage.objects.delete` permission is not
 granted, there will be an unrecoverable error. Usage of `%{hex_random}` is
 recommended.
 

--- a/lib/fluent/plugin/gcs/version.rb
+++ b/lib/fluent/plugin/gcs/version.rb
@@ -1,5 +1,5 @@
 module Fluent
   module GCSPlugin
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -153,7 +153,6 @@ module Fluent::Plugin
 
     def check_object_exists(path)
       if !@blind_write
-        log.info "checking `#{path}`"
         return @gcs_bucket.find_file(path, @encryption_opts)
       else
         return false


### PR DESCRIPTION
Add support of  **blind_write**

When using this option, fluentd doesn't check if an object exists in GCS before writing. Default is false.

Allows to avoid granting of `storage.objects.get` permission.