### PR TITLE
Change recursion to loop in generate_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/test/plugin/test_out_gcs.rb
+++ b/test/plugin/test_out_gcs.rb
@@ -19,6 +19,9 @@ class GCSOutputTest < Test::Unit::TestCase
       @type memory
       timekey_use_utc true
     </buffer>
+    <system>
+      log_level debug
+    </system>
   EOC
 
   def create_driver(conf = CONFIG)


### PR DESCRIPTION
Iterative implementation for `generate_path()` will reduce the risk of stack overflow due to recursion. This change could mitigate https://github.com/daichirata/fluent-plugin-gcs/issues/17.

I new to Ruby and have some trouble with the unit test failures... @daichirata @cosmo0920 could you help me take a look?