### PR TITLE
docs: update fluentd formatter documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Change one line format in the GCS object. You can use serveral format:
 * ltsv
 * single_value
 
-See also [official Formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
+See also [official Formatter article](https://docs.fluentd.org/formatter).
 
 **auto_create_bucket**
 


### PR DESCRIPTION
## Summary
  Updates the broken link to fluentd's formatter documentation in the README.

  ## Changes
  - Updated the formatter documentation URL from the old format
  (`http://docs.fluentd.org/articles/formatter-plugin-overview`) to the current format
  (`https://docs.fluentd.org/formatter`)
  - Changed from HTTP to HTTPS for security

  ## Context
  The old URL returns a 404 error as fluentd has restructured their documentation. This PR updates the link to
   point to the correct location in their current documentation structure.

<img width="1375" alt="image" src="https://github.com/user-attachments/assets/810cc3f4-1684-42c6-b984-91ae89c26b12" />
