### PR TITLE
Add gzip_command compression option for improved performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,28 @@ GCS bucket name.
 Archive format on GCS. You can use serveral format:
 
 * gzip (default)
+* gzip_command
 * json
 * text
+
+`gzip_command` uses an external gzip command for compression, which can provide better performance than Ruby's built-in `Zlib::GzipWriter` for large data volumes. If the gzip command fails, it automatically falls back to `Zlib::GzipWriter`.
+
+**gzip_command_parameter**
+
+Additional parameters for gzip command when using `store_as gzip_command`. Default is "" (no parameters).
+
+For example:
+* `-1` - Fast compression (less compression ratio, faster speed)
+* `-9` - Best compression (higher compression ratio, slower speed)
+
+```
+<match pattern>
+  @type gcs
+  store_as gzip_command
+  gzip_command_parameter -1
+  ...
+</match>
+```
 
 **path**
 
@@ -132,6 +152,7 @@ to decide keys dynamically.
 * `%{index}` is the sequential number starts from 0, increments when multiple files are uploaded to GCS in the same time slice.
 * `%{file_extention}` is changed by the value of `store_as`.
   * gzip - gz
+  * gzip_command - gz
   * json - json
   * text - txt
 * `%{uuid_flush}` a uuid that is replaced everytime the buffer will be flushed

--- a/lib/fluent/plugin/gcs/object_creator.rb
+++ b/lib/fluent/plugin/gcs/object_creator.rb
@@ -1,12 +1,19 @@
 require "tempfile"
 require "zlib"
+require "open3"
 
 module Fluent
   module GCS
-    def self.discovered_object_creator(store_as, transcoding: nil)
+    def self.discovered_object_creator(store_as, transcoding: nil, command_parameter: nil, log: nil)
       case store_as
       when :gzip
         Fluent::GCS::GZipObjectCreator.new(transcoding)
+      when :gzip_command
+        Fluent::GCS::GZipCommandObjectCreator.new(
+          transcoding: transcoding,
+          command_parameter: command_parameter,
+          log: log
+        )
       when :json
         Fluent::GCS::JSONObjectCreator.new
       when :text
@@ -59,6 +66,61 @@ module Fluent
       end
 
       def write(chunk, io)
+        writer = Zlib::GzipWriter.new(io)
+        chunk.write_to(writer)
+        writer.finish
+      end
+    end
+
+    class GZipCommandObjectCreator < ObjectCreator
+      def initialize(transcoding:, command_parameter:, log:)
+        @transcoding = transcoding
+        @command_parameter = command_parameter || ""
+        @log = log
+        check_gzip_command
+      end
+
+      def content_type
+        @transcoding ? "text/plain" : "application/gzip"
+      end
+
+      def content_encoding
+        @transcoding ? "gzip" : nil
+      end
+
+      def file_extension
+        "gz"
+      end
+
+      def write(chunk, io)
+        Tempfile.create("gzip-chunk-tmp") do |chunk_file|
+          chunk_file.binmode
+          chunk.write_to(chunk_file)
+          chunk_file.close
+
+          command = "gzip #{@command_parameter} -c #{chunk_file.path}"
+          result = system("#{command} > #{io.path}")
+
+          unless result
+            @log&.warn("failed to execute gzip command. Fallback to GzipWriter. status = #{$?}")
+            io.truncate(0)
+            io.rewind
+            fallback_to_gzip_writer(chunk, io)
+          end
+        end
+      end
+
+      private
+
+      def check_gzip_command
+        begin
+          Open3.capture3("gzip -V")
+        rescue Errno::ENOENT
+          raise Fluent::ConfigError, "'gzip' utility must be in PATH for gzip_command compression"
+        end
+      end
+
+      def fallback_to_gzip_writer(chunk, io)
         writer = Zlib::GzipWriter.new(io)
         chunk.write_to(writer)
         writer.finish

--- a/lib/fluent/plugin/gcs/object_creator.rb
+++ b/lib/fluent/plugin/gcs/object_creator.rb
@@ -1,6 +1,7 @@
 require "tempfile"
 require "zlib"
 require "open3"
+require "shellwords"
 
 module Fluent
   module GCS
@@ -93,20 +94,18 @@ module Fluent
       end
 
       def write(chunk, io)
-        Tempfile.create("gzip-chunk-tmp") do |chunk_file|
-          chunk_file.binmode
-          chunk.write_to(chunk_file)
-          chunk_file.close
+        cmd = ["gzip", *@command_parameter.shellsplit, "-c"]
+        status = Open3.pipeline_w(cmd, out: io.path) do |stdin, wait_thrs|
+          chunk.write_to(stdin)
+          stdin.close
+          wait_thrs.last.value
+        end
 
-          command = "gzip #{@command_parameter} -c #{chunk_file.path}"
-          result = system("#{command} > #{io.path}")
-
-          unless result
-            @log&.warn("failed to execute gzip command. Fallback to GzipWriter. status = #{$?}")
-            io.truncate(0)
-            io.rewind
-            fallback_to_gzip_writer(chunk, io)
-          end
+        unless status.success?
+          @log&.warn("failed to execute gzip command. Fallback to GzipWriter. status = #{status}")
+          io.truncate(0)
+          io.rewind
+          fallback_to_gzip_writer(chunk, io)
         end
       end
 

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -34,10 +34,12 @@ module Fluent::Plugin
                  desc: "Format of GCS object keys"
     config_param :path, :string, default: "",
                  desc: "Path prefix of the files on GCS"
-    config_param :store_as, :enum, list: %i(gzip json text), default: :gzip,
+    config_param :store_as, :enum, list: %i(gzip gzip_command json text), default: :gzip,
                  desc: "Archive format on GCS"
     config_param :transcoding, :bool, default: false,
                  desc: "Enable the decompressive form of transcoding"
+    config_param :gzip_command_parameter, :string, default: "",
+                 desc: "Additional parameters for gzip command (e.g. '-1' for fast compression)"
     config_param :auto_create_bucket, :bool, default: true,
                  desc: "Create GCS bucket if it does not exists"
     config_param :hex_random_length, :integer, default: 4,
@@ -91,7 +93,12 @@ module Fluent::Plugin
 
       @formatter = formatter_create
 
-      @object_creator = Fluent::GCS.discovered_object_creator(@store_as, transcoding: @transcoding)
+      @object_creator = Fluent::GCS.discovered_object_creator(
+        @store_as,
+        transcoding: @transcoding,
+        command_parameter: @gzip_command_parameter,
+        log: log
+      )
       # For backward compatibility
       # TODO: Remove time_slice_format when end of support compat_parameters
       @configured_time_slice_format = conf['time_slice_format']

--- a/test/plugin/test_object_creator.rb
+++ b/test/plugin/test_object_creator.rb
@@ -1,5 +1,6 @@
 require "helper"
 require "zlib"
+require "tmpdir"
 
 class GCSObjectCreatorTest < Test::Unit::TestCase
   DUMMY_DATA = %[2016-01-01T12:00:00Z\ttest\t{"a":1,"tag":"test","time":"2016-01-01T12:00:00Z"}\n] +
@@ -104,6 +105,36 @@ class GCSObjectCreatorTest < Test::Unit::TestCase
         c.write(DummyChunk.new, f)
         Zlib::GzipReader.open(f.path) do |gz|
           assert_equal DUMMY_DATA, gz.read
+        end
+      end
+    end
+
+    def test_write_fallback_to_gzip_writer_on_command_failure
+      Dir.mktmpdir do |bin_dir|
+        fake_gzip = File.join(bin_dir, "gzip")
+        File.write(fake_gzip, "#!/bin/sh\nexit 1\n")
+        File.chmod(0755, fake_gzip)
+
+        original_path = ENV["PATH"]
+        ENV["PATH"] = "#{bin_dir}:#{original_path}"
+        begin
+          Tempfile.create("test_object_creator") do |f|
+            f.binmode
+            f.sync = true
+
+            log = DummyLog.new
+            c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: false, command_parameter: "", log: log)
+            c.write(DummyChunk.new, f)
+
+            assert_equal 1, log.warnings.size
+            assert_match(/Fallback to GzipWriter/, log.warnings.first)
+
+            Zlib::GzipReader.open(f.path) do |gz|
+              assert_equal DUMMY_DATA, gz.read
+            end
+          end
+        ensure
+          ENV["PATH"] = original_path
         end
       end
     end

--- a/test/plugin/test_object_creator.rb
+++ b/test/plugin/test_object_creator.rb
@@ -51,6 +51,64 @@ class GCSObjectCreatorTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case "GZipCommandObjectCreator" do
+    class DummyLog
+      attr_reader :warnings
+
+      def initialize
+        @warnings = []
+      end
+
+      def warn(message)
+        @warnings << message
+      end
+    end
+
+    def test_content_type_and_content_encoding
+      c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: true, command_parameter: "", log: nil)
+      assert_equal "text/plain", c.content_type
+      assert_equal "gzip", c.content_encoding
+
+      c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: false, command_parameter: "", log: nil)
+      assert_equal "application/gzip", c.content_type
+      assert_equal nil, c.content_encoding
+    end
+
+    def test_file_extension
+      c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: true, command_parameter: "", log: nil)
+      assert_equal "gz", c.file_extension
+
+      c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: false, command_parameter: "", log: nil)
+      assert_equal "gz", c.file_extension
+    end
+
+    def test_write
+      Tempfile.create("test_object_creator") do |f|
+        f.binmode
+        f.sync = true
+
+        c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: true, command_parameter: "", log: nil)
+        c.write(DummyChunk.new, f)
+        Zlib::GzipReader.open(f.path) do |gz|
+          assert_equal DUMMY_DATA, gz.read
+        end
+      end
+    end
+
+    def test_write_with_command_parameter
+      Tempfile.create("test_object_creator") do |f|
+        f.binmode
+        f.sync = true
+
+        c = Fluent::GCS::GZipCommandObjectCreator.new(transcoding: false, command_parameter: "-1", log: nil)
+        c.write(DummyChunk.new, f)
+        Zlib::GzipReader.open(f.path) do |gz|
+          assert_equal DUMMY_DATA, gz.read
+        end
+      end
+    end
+  end
+
   sub_test_case "TextObjectCreator" do
     def test_content_type_and_content_encoding
       c = Fluent::GCS::TextObjectCreator.new

--- a/test/plugin/test_out_gcs.rb
+++ b/test/plugin/test_out_gcs.rb
@@ -77,6 +77,17 @@ class GCSOutputTest < Test::Unit::TestCase
       driver = create_driver(config(CONFIG, "store_as json"))
       assert_equal true, driver.instance.object_creator.is_a?(Fluent::GCS::JSONObjectCreator)
     end
+
+    def test_configure_with_gzip_command_object_creator
+      driver = create_driver(config(CONFIG, "store_as gzip_command"))
+      assert_equal true, driver.instance.object_creator.is_a?(Fluent::GCS::GZipCommandObjectCreator)
+    end
+
+    def test_configure_with_gzip_command_parameter
+      driver = create_driver(config(CONFIG, "store_as gzip_command", "gzip_command_parameter -1"))
+      assert_equal true, driver.instance.object_creator.is_a?(Fluent::GCS::GZipCommandObjectCreator)
+      assert_equal "-1", driver.instance.gzip_command_parameter
+    end
   end
 
   def test_start
@@ -325,6 +336,44 @@ class GCSOutputTest < Test::Unit::TestCase
       }.merge(enc_opts)
 
       check_upload(conf, "log/20160101_0.json", enc_opts, upload_opts)
+    end
+
+    def test_write_with_gzip_command
+      conf = config(CONFIG, "store_as gzip_command")
+
+      enc_opts = {
+        encryption_key: nil,
+      }
+
+      upload_opts = {
+        metadata: {},
+        acl: nil,
+        storage_class: nil,
+        content_type: "application/gzip",
+        content_encoding: nil,
+        encryption_key: nil,
+      }.merge(enc_opts)
+
+      check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
+    end
+
+    def test_write_with_gzip_command_and_transcoding
+      conf = config(CONFIG, "store_as gzip_command", "transcoding true")
+
+      enc_opts = {
+        encryption_key: nil,
+      }
+
+      upload_opts = {
+        metadata: {},
+        acl: nil,
+        storage_class: nil,
+        content_type: "text/plain",
+        content_encoding: "gzip",
+        encryption_key: nil,
+      }.merge(enc_opts)
+
+      check_upload(conf, "log/20160101_0.gz", enc_opts, upload_opts)
     end
 
     def test_write_with_utc


### PR DESCRIPTION
Supersedes #31 (by @tomopy03). Picks up tomopy03's commits and addresses the review feedback so we can merge from this repository.

## Summary

Add `gzip_command` as a new `store_as` option that uses an external `gzip` command for compression instead of Ruby's built-in `Zlib::GzipWriter`. Inspired by [fluent-plugin-s3's gzip_command implementation](https://github.com/fluent/fluent-plugin-s3).

## Changes

- Add `GZipCommandObjectCreator` class that executes external gzip command
- Add `store_as gzip_command` option
- Add `gzip_command_parameter` config for passing additional gzip options (e.g., `-1` for fast compression, `-9` for best compression)
- Automatic fallback to `Zlib::GzipWriter` if gzip command fails
- Add unit tests and integration tests
- Update README documentation

## Review feedback addressed (vs #31)

- **Shell-safe argument passing**: `gzip_command_parameter` is no longer interpolated into a shell string. `Open3.pipeline_w` with `shellsplit`-parsed args is used so a value like `-1; rm -rf /tmp/foo` is passed as a literal argument rather than executed as a shell command.
- **No redundant disk I/O**: The chunk is piped directly into `gzip`'s stdin instead of being written to an intermediate tempfile, halving disk I/O for large chunks.
- **Fallback path is now covered by tests**: A new test injects a fake `gzip` binary via `PATH` that always exits non-zero and asserts the `Zlib::GzipWriter` fallback still produces a valid gzip stream.

## Usage

```apache
<match pattern>
  @type gcs
  store_as gzip_command
  gzip_command_parameter -1
  ...
</match>
```

## Test plan

- [x] `bundle exec rake test` — 45 tests, 67 assertions, 0 failures