### PR TITLE
Point CI triggers at the main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Preparation step for renaming the default branch from \`master\` to \`main\`. Updates the workflow triggers so that after the rename the test workflow continues to run on the renamed branch.

## Changes

* \`branches: [master]\` → \`branches: [main]\` for \`push\` and \`pull_request\` triggers
* \`concurrency.cancel-in-progress\` ref check now compares against \`refs/heads/main\`

## Test plan

After this is merged, rename the branch via \`gh api -X POST repos/daichirata/fluent-plugin-gcs/branches/master/rename -f new_name=main\`. GitHub will redirect existing PRs (\`#34\`, \`#35\`) automatically.