### PR TITLE
Drop fluentd v0.12 compatibility and align with the v1 plugin style

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ Google Cloud Storage output plugin for [Fluentd](https://github.com/fluent/fluen
 
 ## Requirements
 
-| fluent-plugin-gcs | fluentd     | ruby   |
-|-------------------|-------------|--------|
-| >= 0.4.5          | >= 0.14.22  | >= 3.3 |
-| >= 0.4.0          | >= 0.14.22  | >= 2.4 |
-| <  0.4.0          | >= 0.12.0   | >= 1.9 |
+| fluent-plugin-gcs | fluentd  | ruby   |
+|-------------------|----------|--------|
+| >= 0.5.0          | >= 1.0   | >= 3.3 |
 
 ## Installation
 

--- a/fluent-plugin-gcs.gemspec
+++ b/fluent-plugin-gcs.gemspec
@@ -1,7 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'fluent/plugin/gcs/version'
+require_relative "lib/fluent/plugin/gcs/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-gcs"
@@ -9,17 +6,25 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Daichi HIRATA"]
   spec.email         = ["hirata.daichi@gmail.com"]
   spec.summary       = "Google Cloud Storage output plugin for Fluentd"
-  spec.description   = "Google Cloud Storage output plugin for Fluentd"
+  spec.description   = "Fluentd output plugin that buffers events and uploads them to Google Cloud Storage as gzip, json, or text objects."
   spec.homepage      = "https://github.com/daichirata/fluent-plugin-gcs"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.required_ruby_version = ">= 3.3"
+
+  spec.metadata = {
+    "source_code_uri"       => spec.homepage,
+    "bug_tracker_uri"       => "#{spec.homepage}/issues",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", [">= 0.14.22", "< 2"]
+  spec.add_runtime_dependency "fluentd", ">= 1.0", "< 3"
   spec.add_runtime_dependency "google-cloud-storage", "~> 1.1"
 end

--- a/lib/fluent/plugin/gcs/version.rb
+++ b/lib/fluent/plugin/gcs/version.rb
@@ -1,5 +1,5 @@
 module Fluent
   module GCSPlugin
-    VERSION = "0.4.5"
+    VERSION = "0.5.0"
   end
 end

--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -10,7 +10,7 @@ module Fluent::Plugin
   class GCSOutput < Output
     Fluent::Plugin.register_output("gcs", self)
 
-    helpers :compat_parameters, :formatter, :inject
+    helpers :formatter, :inject
 
     def initialize
       super
@@ -46,8 +46,6 @@ module Fluent::Plugin
                  desc: "Max length of `%{hex_random}` placeholder(4-16)"
     config_param :overwrite, :bool, default: false,
                  desc: "Overwrite already existing path"
-    config_param :format, :string, default: "out_file",
-                 desc: "Change one line format in the GCS object"
     config_param :acl, :enum, list: %i(auth_read owner_full owner_read private project_private public_read), default: nil,
                  desc: "Permission for the object in GCS"
     config_param :storage_class, :enum, list: %i(dra nearline coldline multi_regional regional standard), default: nil,
@@ -61,10 +59,8 @@ module Fluent::Plugin
       config_param :value, :string, default: ""
     end
 
-    DEFAULT_FORMAT_TYPE = "out_file"
-
     config_section :format do
-      config_set_default :@type, DEFAULT_FORMAT_TYPE
+      config_set_default :@type, "out_file"
     end
 
     config_section :buffer do
@@ -75,7 +71,6 @@ module Fluent::Plugin
     MAX_HEX_RANDOM_LENGTH = 32
 
     def configure(conf)
-      compat_parameters_convert(conf, :buffer, :formatter, :inject)
       super
 
       if @hex_random_length > MAX_HEX_RANDOM_LENGTH
@@ -99,10 +94,7 @@ module Fluent::Plugin
         command_parameter: @gzip_command_parameter,
         log: log
       )
-      # For backward compatibility
-      # TODO: Remove time_slice_format when end of support compat_parameters
-      @configured_time_slice_format = conf['time_slice_format']
-      @time_slice_with_tz = Fluent::Timezone.formatter(@timekey_zone, @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey']))
+      @time_slice_with_tz = Fluent::Timezone.formatter(@timekey_zone, timekey_to_timeformat(@buffer_config['timekey']))
 
       if @credentials_json
         @credentials = @credentials_json

--- a/test/plugin/test_out_gcs.rb
+++ b/test/plugin/test_out_gcs.rb
@@ -49,6 +49,14 @@ class GCSOutputTest < Test::Unit::TestCase
     { encryption_key: nil }.merge(overrides)
   end
 
+  def format_section(type)
+    "<format>\n  @type #{type}\n</format>"
+  end
+
+  def inject_section(*lines)
+    (["<inject>"] + lines.map { |l| "  #{l}" } + ["</inject>"]).join("\n")
+  end
+
   sub_test_case "configure" do
     def test_configure
       driver = create_driver
@@ -62,7 +70,6 @@ class GCSOutputTest < Test::Unit::TestCase
       assert_equal true, driver.instance.auto_create_bucket
       assert_equal 4, driver.instance.hex_random_length
       assert_equal false, driver.instance.overwrite
-      assert_equal "out_file", driver.instance.instance_variable_get(:@format)
       assert_equal nil, driver.instance.acl
       assert_equal nil, driver.instance.storage_class
       assert_equal nil, driver.instance.encryption_key
@@ -128,6 +135,40 @@ class GCSOutputTest < Test::Unit::TestCase
       assert_raise Fluent::ConfigError do
         create_driver(config(CONFIG, "#{key} #{value}"))
       end
+    end
+
+    def test_configure_default_formatter_is_out_file
+      driver = create_driver
+      assert_kind_of Fluent::Plugin::OutFileFormatter, driver.instance.instance_variable_get(:@formatter)
+    end
+
+    def test_configure_format_section_overrides_formatter
+      driver = create_driver(config(CONFIG, format_section("json")))
+      assert_kind_of Fluent::Plugin::JSONFormatter, driver.instance.instance_variable_get(:@formatter)
+    end
+
+    def test_configure_default_buffer_settings
+      driver = create_driver
+      buffer = driver.instance.buffer_config
+      assert_equal ["time"], buffer.chunk_keys
+      assert_equal 60 * 60 * 24, buffer.timekey
+    end
+
+    def test_configure_object_metadata_section
+      driver = create_driver(config(CONFIG, <<-EOM))
+        <object_metadata>
+          key k1
+          value v1
+        </object_metadata>
+        <object_metadata>
+          key k2
+          value v2
+        </object_metadata>
+      EOM
+      assert_equal(
+        {"k1" => "v1", "k2" => "v2"},
+        driver.instance.instance_variable_get(:@object_metadata_hash),
+      )
     end
   end
 
@@ -264,7 +305,7 @@ class GCSOutputTest < Test::Unit::TestCase
 
     def test_format_included_tag_and_time
       with_timezone("UTC") do
-        driver = create_driver(config(CONFIG, 'include_tag_key true', 'include_time_key true'))
+        driver = create_driver(config(CONFIG, inject_section("tag_key tag", "time_key time", "time_type string")))
         driver.run(default_tag: "test") do
           driver.feed(@time, {"a"=>1})
           driver.feed(@time, {"a"=>2})
@@ -278,7 +319,7 @@ class GCSOutputTest < Test::Unit::TestCase
 
     def test_format_with_format_ltsv
       with_timezone("UTC") do
-        driver = create_driver(config(CONFIG, 'format ltsv'))
+        driver = create_driver(config(CONFIG, format_section("ltsv")))
         driver.run(default_tag: "test") do
           driver.feed(@time, {"a"=>1, "b"=>1})
           driver.feed(@time, {"a"=>2, "b"=>2})
@@ -290,7 +331,7 @@ class GCSOutputTest < Test::Unit::TestCase
 
     def test_format_with_format_json
       with_timezone("UTC") do
-        driver = create_driver(config(CONFIG, 'format json'))
+        driver = create_driver(config(CONFIG, format_section("json")))
         driver.run(default_tag: "test") do
           driver.feed(@time, {"a"=>1})
           driver.feed(@time, {"a"=>2})
@@ -302,7 +343,7 @@ class GCSOutputTest < Test::Unit::TestCase
 
     def test_format_with_format_json_included_tag
       with_timezone("UTC") do
-        driver = create_driver(config(CONFIG, 'format json', 'include_tag_key true'))
+        driver = create_driver(config(CONFIG, format_section("json"), inject_section("tag_key tag")))
         driver.run(default_tag: "test") do
           driver.feed(@time, {"a"=>1})
           driver.feed(@time, {"a"=>2})
@@ -314,7 +355,7 @@ class GCSOutputTest < Test::Unit::TestCase
 
     def test_format_with_format_json_included_time
       with_timezone("UTC") do
-        driver = create_driver(config(CONFIG, 'format json', 'include_time_key true'))
+        driver = create_driver(config(CONFIG, format_section("json"), inject_section("time_key time", "time_type string")))
         driver.run(default_tag: "test") do
           driver.feed(@time, {"a"=>1})
           driver.feed(@time, {"a"=>2})
@@ -326,7 +367,7 @@ class GCSOutputTest < Test::Unit::TestCase
 
     def test_format_with_format_json_included_tag_and_time
       with_timezone("UTC") do
-        driver = create_driver(config(CONFIG, 'format json', 'include_tag_key true', 'include_time_key true'))
+        driver = create_driver(config(CONFIG, format_section("json"), inject_section("tag_key tag", "time_key time", "time_type string")))
         driver.run(default_tag: "test") do
           driver.feed(@time, {"a"=>1})
           driver.feed(@time, {"a"=>2})
@@ -429,23 +470,6 @@ class GCSOutputTest < Test::Unit::TestCase
       CONFIG
 
       check_upload(conf, "log/0.gz", enc_opts, upload_opts)
-    end
-
-    def test_write_with_custom_time_slice_format
-      conf = <<-CONFIG
-        project test_project
-        keyfile test_keyfile
-        bucket test_bucket
-        path log/
-        time_slice_format %Y/%m/%d/%H
-        <buffer>
-          @type memory
-          timekey 3600
-          timekey_use_utc true
-        </buffer>
-      CONFIG
-
-      check_upload(conf, "log/2016/01/01/15_0.gz", enc_opts, upload_opts)
     end
 
     def test_write_with_encryption


### PR DESCRIPTION
## Summary

Cuts the fluentd v0.12 compatibility layer and aligns the plugin with the modern v1.x plugin style. Bumps to **0.5.0** as a minor release because the changes are backward-incompatible for anyone still using v0.12 style configuration.

## Breaking changes

- Require \`fluentd >= 1.0\`. v0.12 is no longer supported.
- Drop the \`compat_parameters\` helper. The following top-level parameters are no longer accepted and must be expressed using sections instead:

| Old (v0.12 style)        | New (v1 style) |
|--------------------------|----------------|
| \`format json\`            | \`<format>\n  @type json\n</format>\` |
| \`include_tag_key true\`   | \`<inject>\n  tag_key tag\n</inject>\` |
| \`include_time_key true\`  | \`<inject>\n  time_key time\n  time_type string\n</inject>\` |
| \`tag_key\` / \`time_key\` / \`time_format\` / \`time_type\` / \`localtime\` / \`utc\` | \`<inject>\` section |
| \`time_slice_format\`      | \`<buffer>\` with \`timekey\` |
| \`buffer_path\` / \`time_slice_wait\` | \`<buffer>\` section |

## Internal changes

- Remove the \`time_slice_format\` fallback in \`configure\`; the time format is derived directly from the \`<buffer>\` \`timekey\`.
- Modernize the gemspec:
  - \`required_ruby_version: \">= 3.3\"\`
  - Add \`metadata\` (\`source_code_uri\`, \`bug_tracker_uri\`, \`rubygems_mfa_required\`)
  - Distinguish \`summary\` from \`description\`
  - Remove the legacy \`# coding: utf-8\` magic comment and the \`\$LOAD_PATH.unshift\` idiom in favor of \`require_relative\`

## Tests

- Drop the test that exercised the deprecated \`time_slice_format\`
- Rewrite format/inject tests to use the new \`<format>\` and \`<inject>\` sections via small helpers
- Add config tests covering:
  - default formatter is \`OutFileFormatter\`
  - \`<format>\` section overrides the formatter
  - default \`<buffer>\` values (\`chunk_keys: [\"time\"]\`, \`timekey: 86400\`)
  - \`<object_metadata>\` parsing

## README

- Trim the Requirements table to the currently supported combination only (\`fluent-plugin-gcs >= 0.5.0\`, \`fluentd >= 1.0\`, \`ruby >= 3.3\`)

## Test plan

- [x] \`bundle exec rake test\` (61 tests, 128 assertions, 0 failures)
- [x] \`gem build fluent-plugin-gcs.gemspec\` succeeds without warnings